### PR TITLE
Add interactive trip route planner web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Trip Route Planner</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-sA+e2at9m0f71TnU5G4s+6U86p2zU1hbY5mS0h3yGxo="
+      crossorigin=""
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet-routing-machine@3.2.12/dist/leaflet-routing-machine.css"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Trip Route Planner</h1>
+      <p>
+        Add a starting point and points of interest to explore different ways to
+        connect them by car, on foot, or by air.
+      </p>
+    </header>
+    <main>
+      <section class="controls">
+        <div class="control-card">
+          <h2>Locations</h2>
+          <div class="field-group">
+            <label for="start-address">Start location</label>
+            <div class="inline">
+              <input
+                type="text"
+                id="start-address"
+                placeholder="Search for a starting address"
+              />
+              <button id="start-search" type="button">Search</button>
+            </div>
+            <button id="use-map-start" type="button">
+              Select on map
+            </button>
+          </div>
+          <div class="field-group">
+            <label for="poi-address">Point of interest</label>
+            <div class="inline">
+              <input
+                type="text"
+                id="poi-address"
+                placeholder="Search for a point of interest"
+              />
+              <button id="poi-search" type="button">Add</button>
+            </div>
+            <button id="use-map-poi" type="button">Add from map</button>
+          </div>
+          <p id="map-hint" class="hint" aria-live="polite"></p>
+          <div class="field-group">
+            <label>Points of interest</label>
+            <ul id="poi-list"></ul>
+          </div>
+        </div>
+        <div class="control-card">
+          <h2>Routes</h2>
+          <p>
+            Choose which routes to display. The flight path shows a geodesic arc
+            between each stop.
+          </p>
+          <div class="toggle">
+            <input type="checkbox" id="toggle-driving" checked />
+            <label for="toggle-driving">Driving route</label>
+          </div>
+          <div class="toggle">
+            <input type="checkbox" id="toggle-walking" checked />
+            <label for="toggle-walking">Walking / subway route</label>
+          </div>
+          <div class="toggle">
+            <input type="checkbox" id="toggle-flight" checked />
+            <label for="toggle-flight">Flight path</label>
+          </div>
+          <button id="clear-pois" type="button" class="danger">
+            Clear points of interest
+          </button>
+        </div>
+      </section>
+      <section class="map-container">
+        <div id="map"></div>
+      </section>
+    </main>
+    <footer>
+      <p>
+        Routing powered by the open-source OSRM API. Geocoding via OpenStreetMap
+        Nominatim.
+      </p>
+    </footer>
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-o9N1j7kGStb0P94p42Wg9WOx1sGkGWDKzrHf2z8IiQY="
+      crossorigin=""
+    ></script>
+    <script src="https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.js"></script>
+    <script src="https://unpkg.com/leaflet-routing-machine@3.2.12/dist/leaflet-routing-machine.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.geodesic/1.2.1/leaflet.geodesic.min.js"></script>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,314 @@
+const map = L.map('map', {
+  zoomControl: false,
+}).setView([20, 0], 2);
+
+L.control.zoom({ position: 'topright' }).addTo(map);
+
+const tileLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  maxZoom: 19,
+  attribution:
+    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+});
+
+tileLayer.addTo(map);
+
+let startMarker = null;
+let pois = [];
+let drivingRoute = null;
+let walkingRoute = null;
+let flightLayer = null;
+let pendingMapMode = null;
+
+const startInput = document.getElementById('start-address');
+const startSearchBtn = document.getElementById('start-search');
+const startMapBtn = document.getElementById('use-map-start');
+const poiInput = document.getElementById('poi-address');
+const poiSearchBtn = document.getElementById('poi-search');
+const poiMapBtn = document.getElementById('use-map-poi');
+const poiList = document.getElementById('poi-list');
+const mapHint = document.getElementById('map-hint');
+const drivingToggle = document.getElementById('toggle-driving');
+const walkingToggle = document.getElementById('toggle-walking');
+const flightToggle = document.getElementById('toggle-flight');
+const clearPoisBtn = document.getElementById('clear-pois');
+
+const geocoder = L.Control.Geocoder.nominatim();
+
+function setMapHint(message = '') {
+  mapHint.textContent = message;
+}
+
+function setStart(latlng, label) {
+  if (startMarker) {
+    startMarker.setLatLng(latlng);
+  } else {
+    startMarker = L.marker(latlng, { title: label }).addTo(map);
+  }
+  startMarker.bindPopup(`<strong>Start:</strong> ${label}`).openPopup();
+  fitMapToPoints();
+  updateRoutes();
+}
+
+function addPoi(latlng, label) {
+  const marker = L.marker(latlng, { title: label }).addTo(map);
+  marker.bindPopup(`<strong>POI:</strong> ${label}`);
+  const poi = {
+    id: generateId(),
+    marker,
+    label,
+  };
+  pois.push(poi);
+  renderPoiList();
+  fitMapToPoints();
+  updateRoutes();
+}
+
+function removePoi(id) {
+  const index = pois.findIndex((poi) => poi.id === id);
+  if (index === -1) return;
+  const [removed] = pois.splice(index, 1);
+  map.removeLayer(removed.marker);
+  renderPoiList();
+  fitMapToPoints();
+  updateRoutes();
+}
+
+function clearPois() {
+  pois.forEach((poi) => map.removeLayer(poi.marker));
+  pois = [];
+  renderPoiList();
+  updateRoutes();
+}
+
+function renderPoiList() {
+  poiList.innerHTML = '';
+  if (pois.length === 0) {
+    const empty = document.createElement('li');
+    empty.textContent = 'No points added yet.';
+    empty.className = 'hint';
+    poiList.appendChild(empty);
+    return;
+  }
+  pois.forEach((poi, index) => {
+    const item = document.createElement('li');
+    item.className = 'poi-item';
+    const label = document.createElement('span');
+    label.textContent = `${index + 1}. ${poi.label}`;
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.textContent = 'Remove';
+    removeBtn.addEventListener('click', () => removePoi(poi.id));
+    item.append(label, removeBtn);
+    poiList.appendChild(item);
+  });
+}
+
+function getWaypoints() {
+  if (!startMarker || pois.length === 0) {
+    return null;
+  }
+  const startPoint = startMarker.getLatLng();
+  const poiPoints = pois.map((poi) => poi.marker.getLatLng());
+  return [startPoint, ...poiPoints];
+}
+
+function fitMapToPoints() {
+  const points = [];
+  if (startMarker) {
+    points.push(startMarker.getLatLng());
+  }
+  pois.forEach((poi) => points.push(poi.marker.getLatLng()));
+  if (points.length === 0) return;
+  if (points.length === 1) {
+    map.setView(points[0], 13);
+    return;
+  }
+  const bounds = L.latLngBounds(points);
+  map.fitBounds(bounds.pad(0.2));
+}
+
+function teardownRoute(control) {
+  if (!control) return null;
+  map.removeControl(control);
+  return null;
+}
+
+function updateRoutes() {
+  const waypoints = getWaypoints();
+  if (!waypoints) {
+    drivingRoute = teardownRoute(drivingRoute);
+    walkingRoute = teardownRoute(walkingRoute);
+    if (flightLayer) {
+      map.removeLayer(flightLayer);
+      flightLayer = null;
+    }
+    return;
+  }
+
+  if (drivingToggle.checked) {
+    if (!drivingRoute) {
+      drivingRoute = createRoutingControl('car', '#1d4ed8', waypoints);
+    }
+    drivingRoute.getPlan().setWaypoints(waypoints);
+  } else {
+    drivingRoute = teardownRoute(drivingRoute);
+  }
+
+  if (walkingToggle.checked) {
+    if (!walkingRoute) {
+      walkingRoute = createRoutingControl('foot', '#10b981', waypoints);
+    }
+    walkingRoute.getPlan().setWaypoints(waypoints);
+  } else {
+    walkingRoute = teardownRoute(walkingRoute);
+  }
+
+  if (flightToggle.checked) {
+    drawFlightPath(waypoints);
+  } else if (flightLayer) {
+    map.removeLayer(flightLayer);
+    flightLayer = null;
+  }
+}
+
+function createRoutingControl(profile, color, waypoints) {
+  const control = L.Routing.control({
+    waypoints: waypoints || [],
+    router: L.Routing.osrmv1({
+      serviceUrl: 'https://router.project-osrm.org/route/v1',
+      profile,
+    }),
+    lineOptions: {
+      styles: [
+        {
+          color,
+          weight: 6,
+          opacity: 0.8,
+        },
+      ],
+    },
+    fitSelectedRoutes: false,
+    show: false,
+    addWaypoints: false,
+    routeWhileDragging: false,
+    draggableWaypoints: false,
+    createMarker: () => null,
+  }).addTo(map);
+
+  control.on('routingerror', (event) => {
+    console.error('Routing error', event);
+  });
+
+  return control;
+}
+
+function drawFlightPath(waypoints) {
+  if (flightLayer) {
+    map.removeLayer(flightLayer);
+  }
+  if (!waypoints || waypoints.length < 2) {
+    flightLayer = null;
+    return;
+  }
+  const segments = [];
+  for (let i = 0; i < waypoints.length - 1; i += 1) {
+    segments.push([waypoints[i], waypoints[i + 1]]);
+  }
+  flightLayer = L.geodesic(segments, {
+    weight: 4,
+    opacity: 0.6,
+    color: '#f97316',
+    steps: 100,
+  }).addTo(map);
+}
+
+function generateId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+async function geocodeSearch(query) {
+  if (!query) return null;
+  return new Promise((resolve) => {
+    geocoder.geocode(query, (results) => {
+      resolve(results && results.length ? results[0] : null);
+    });
+  });
+}
+
+async function handleStartSearch() {
+  const query = startInput.value.trim();
+  if (!query) return;
+  setMapHint('Searching for start location...');
+  const result = await geocodeSearch(query);
+  setMapHint('');
+  if (!result) {
+    alert('No results found for the start location.');
+    return;
+  }
+  setStart(result.center, result.name || result.html || query);
+}
+
+async function handlePoiSearch() {
+  const query = poiInput.value.trim();
+  if (!query) return;
+  setMapHint('Searching for point of interest...');
+  const result = await geocodeSearch(query);
+  setMapHint('');
+  if (!result) {
+    alert('No results found for that point of interest.');
+    return;
+  }
+  addPoi(result.center, result.name || result.html || query);
+  poiInput.value = '';
+}
+
+function enableMapSelection(mode) {
+  pendingMapMode = mode;
+  if (mode === 'start') {
+    setMapHint('Click on the map to choose the start location.');
+  } else {
+    setMapHint('Click on the map to add a point of interest.');
+  }
+}
+
+map.on('click', (event) => {
+  if (!pendingMapMode) return;
+  const label = `${pendingMapMode === 'start' ? 'Start' : 'POI'} (${event.latlng.lat.toFixed(
+    4
+  )}, ${event.latlng.lng.toFixed(4)})`;
+  if (pendingMapMode === 'start') {
+    setStart(event.latlng, label);
+  } else {
+    addPoi(event.latlng, label);
+  }
+  pendingMapMode = null;
+  setMapHint('');
+});
+
+startSearchBtn.addEventListener('click', handleStartSearch);
+startInput.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter') {
+    handleStartSearch();
+  }
+});
+
+poiSearchBtn.addEventListener('click', handlePoiSearch);
+poiInput.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter') {
+    handlePoiSearch();
+  }
+});
+
+startMapBtn.addEventListener('click', () => enableMapSelection('start'));
+poiMapBtn.addEventListener('click', () => enableMapSelection('poi'));
+
+drivingToggle.addEventListener('change', updateRoutes);
+walkingToggle.addEventListener('change', updateRoutes);
+flightToggle.addEventListener('change', updateRoutes);
+clearPoisBtn.addEventListener('click', clearPois);
+
+renderPoiList();
+setMapHint('Search above or use the map to start planning.');

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,209 @@
+:root {
+  --bg: #0f172a;
+  --panel-bg: #ffffff;
+  --accent: #2563eb;
+  --accent-muted: #93c5fd;
+  --text: #111827;
+  --muted: #6b7280;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+header,
+footer {
+  color: #f8fafc;
+  text-align: center;
+  padding: 1.5rem 1rem;
+}
+
+header {
+  background: linear-gradient(135deg, #1d4ed8, #0f172a);
+}
+
+header h1 {
+  margin: 0 0 0.5rem 0;
+  font-size: 2rem;
+}
+
+header p {
+  margin: 0;
+  font-weight: 300;
+  max-width: 48rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+main {
+  display: grid;
+  grid-template-columns: minmax(300px, 380px) 1fr;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  flex: 1;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.control-card {
+  background: var(--panel-bg);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.control-card h2 {
+  margin: 0;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.inline {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.inline input {
+  flex: 1;
+}
+
+input[type='text'] {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+}
+
+button {
+  background: var(--accent);
+  color: white;
+  border: none;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+button:hover {
+  background: #1e40af;
+}
+
+button:disabled {
+  background: #9ca3af;
+  cursor: not-allowed;
+}
+
+button.danger {
+  background: #ef4444;
+}
+
+button.danger:hover {
+  background: #b91c1c;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+  min-height: 1.25rem;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.toggle input[type='checkbox'] {
+  width: 1rem;
+  height: 1rem;
+}
+
+#poi-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.poi-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #eff6ff;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  color: #1e3a8a;
+}
+
+.poi-item button {
+  background: transparent;
+  color: #1e3a8a;
+  border: 1px solid #1e3a8a;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+}
+
+.poi-item button:hover {
+  background: #1e3a8a;
+  color: white;
+}
+
+.map-container {
+  background: var(--panel-bg);
+  border-radius: 1rem;
+  padding: 0.75rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.2);
+}
+
+#map {
+  width: 100%;
+  height: calc(100vh - 6rem);
+  min-height: 400px;
+  border-radius: 0.75rem;
+}
+
+footer {
+  background: #0f172a;
+  font-size: 0.85rem;
+}
+
+footer p {
+  margin: 0;
+  color: var(--muted);
+}
+
+@media (max-width: 960px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  #map {
+    height: 60vh;
+  }
+}


### PR DESCRIPTION
## Summary
- build a single-page trip planner UI with inputs for a start location and multiple points of interest
- integrate Leaflet-based mapping with OSRM driving/walking routes and a geodesic flight path overlay
- style the experience with a responsive two-column layout and contextual map hints

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5900b76e8832b82619d384932da7a